### PR TITLE
Add support for firefox:mac12-arm64

### DIFF
--- a/lib/utils/registry.js
+++ b/lib/utils/registry.js
@@ -68,6 +68,7 @@ const EXECUTABLE_PATHS = {
         'mac10.15': ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox'],
         'mac11': ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox'],
         'mac11-arm64': ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox'],
+        'mac12-arm64': ['firefox', 'Nightly.app', 'Contents', 'MacOS', 'firefox'],
         'win32': ['firefox', 'firefox.exe'],
         'win64': ['firefox', 'firefox.exe'],
     },


### PR DESCRIPTION
This fixes an issue where M1's cannot record with playwright. Without this change playwright cannot find the correct execution path