### PR TITLE
Add linux executable paths

### DIFF
--- a/recordreplay/patch.js
+++ b/recordreplay/patch.js
@@ -4,6 +4,8 @@ const { install } = require("./install");
 
 const EXECUTABLE_PATHS = {
   "darwin:firefox": ["firefox", "Nightly.app", "Contents", "MacOS", "firefox"],
+  "linux:chromium": ["chrome-linux", "chrome"],
+  "linux:firefox": ["firefox", "firefox"],
 };
 
 function getExecutableEntry(name) {


### PR DESCRIPTION
I missed adding the paths for the linux executables in the playwright update so this adds them.