### PR TITLE
Fix install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/playwright",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "description": "A high-level API to automate web browsers",
   "repository": "github:RecordReplay/playwright",
   "homepage": "https://playwright.dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recordreplay/playwright",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "A high-level API to automate web browsers",
   "repository": "github:RecordReplay/playwright",
   "homepage": "https://playwright.dev",

--- a/recordreplay/install.js
+++ b/recordreplay/install.js
@@ -40,7 +40,7 @@ async function install(browserName) {
   await installReplayBrowser(...args);
 }
 
-async function installAll() {
+async function replayInstall() {
   console.log("Installing Replay browsers...");
   try {
     switch (process.platform) {


### PR DESCRIPTION
## Issue
`installAll` was inadvertently defined twice. The second instance was exported so it would trigger an install that might finish but since it wasn't `await`-ed, it might not.

## Resolution

* Rename the second call to `replayInstall` and keep the first `installAll` which awaits.
* Bump the version to 1.83.3 for release
